### PR TITLE
fix escaped antislashes in paths (windows only)

### DIFF
--- a/conf/file.go
+++ b/conf/file.go
@@ -160,11 +160,13 @@ func (f *File) WriteRender(ctx map[string]interface{}, delims []string) error {
 	if fd, err = os.Create(f.NewPath + ".rendered"); err != nil {
 		return err
 	}
-	defer fd.Close()
 
 	if err = t.Execute(fd, ctx); err != nil {
+		fd.Close()
 		return err
 	}
+
+	fd.Close()
 	return os.Rename(rdr, f.NewPath)
 }
 

--- a/conf/root.go
+++ b/conf/root.go
@@ -55,7 +55,7 @@ func (r Root) ExecuteCommands(dir string) {
 
 // NewPath adds the path where the file should be rendered according to the root
 func (r Root) NewPath(f *File, new string) {
-	f.NewPath = strings.Replace(f.Path, r.File.Dir, new, 1)
+	f.NewPath = filepath.ToSlash(strings.Replace(f.Path, r.File.Dir, new, 1))
 }
 
 // NewRootConfig will return the root configuration


### PR DESCRIPTION
I also had to explicitly close the template file before renaming it...